### PR TITLE
Disabled Back culling

### DIFF
--- a/MoonMarkerAV3.shader
+++ b/MoonMarkerAV3.shader
@@ -9,6 +9,7 @@
 	{
 		Tags { "RenderType" = "Opaque" }
 		LOD 100
+		Cull Off
 
 		Pass
 		{


### PR DESCRIPTION
As title says, disabled back culling of the shader, makes it more versatile and useful.